### PR TITLE
Fix: fixed issue with package calling result.xxxx twice for getNumberType

### DIFF
--- a/android/src/main/java/com/codeheadlabs/libphonenumber/LibphonenumberPlugin.java
+++ b/android/src/main/java/com/codeheadlabs/libphonenumber/LibphonenumberPlugin.java
@@ -40,6 +40,7 @@ public class LibphonenumberPlugin implements MethodCallHandler {
         break;
       case "getNumberType":
         handleGetNumberType(call, result);
+        break;
       case "formatAsYouType":
         formatAsYouType(call, result);
         break;


### PR DESCRIPTION
Hi @emostar, libphonenumber package throws java.lang.IllegalStateException: Reply already submitted, whenever getNumberType is called. Here is the PR that has fixed to this issue, I can wait for this to get merged a published. Thanks.