### PR TITLE
Upgrade compileSdkVersion to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This PR upgrades compileSdkVersion to 31. It prevents Flutter apps compiling for Android SDK 31 to fail the build.