### PR TITLE
fix(): Pin libPhoneNumber-iOS dependendy to version 0.9.9 to fix iOS build error

### DIFF
--- a/ios/libphonenumber.podspec
+++ b/ios/libphonenumber.podspec
@@ -15,7 +15,7 @@ Simple implementation of libphonenumber
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'libPhoneNumber-iOS'
+  s.dependency 'libPhoneNumber-iOS', '0.9.9'
   
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
The underlying ios library (libPhoneNumber-iOS) used by this plugin has been updated yesterday from version 0.9.9 to 1.2.0 causing build error on iOS. 
As a workaround to fix the plugin (version 2.0.2), I pin the dependency to version 0.9.9.
But the real fix should be to implement a newer version of the plugin using the latest version of libPhoneNumber-iOS (1.2.0) as it seems to contain breaking changes.
See libPhoneNumber-iOS [cocoapods page](https://cocoapods.org/pods/libPhoneNumber-iOS)